### PR TITLE
Show license numbers in athlete listings

### DIFF
--- a/Eindopdracht_Triathlon_V2.cpp
+++ b/Eindopdracht_Triathlon_V2.cpp
@@ -257,9 +257,10 @@ void lijst_atleten(const vector<Atleet>& lijst)
 
     for (size_t i = 0; i < lijst.size(); ++i)
     {
+        const Licentie& lic = lijst[i].get_licentie();
         cout << "[" << i << "] "
-            << lijst[i].get_voornaam() << " " << lijst[i].get_achternaam() << " | Geb.datum: " << lijst[i].get_geboortedatum() << " | Geslacht: " 
-            << lijst[i].get_geslacht() << " | Licentie: " << lijst[i].get_licentie().get_type() << "\n";
+            << lijst[i].get_voornaam() << " " << lijst[i].get_achternaam() << " | Geb.datum: " << lijst[i].get_geboortedatum() << " | Geslacht: "
+            << lijst[i].get_geslacht() << " | Licentie: " << lic.get_type() << " (" << lic.get_nummer() << ")\n";
     }
 }
 


### PR DESCRIPTION
## Summary
- Display license numbers alongside license types when listing athletes.

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -o triathlon Atleet.cpp Deelnemer.cpp Licentie.cpp Wedstrijd.cpp Eindopdracht_Triathlon_V2.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68b32224e244832081c20c82e7116571