### PR TITLE
Use ja/nee for race creation prompts

### DIFF
--- a/Eindopdracht_Triathlon_V2.cpp
+++ b/Eindopdracht_Triathlon_V2.cpp
@@ -447,7 +447,7 @@ int main() {
         if (keuze == 1)
         {
             string naam, datum;
-            int is_nk_keuze, wissels_keuze;
+            string is_nk_keuze, wissels_keuze;
 
             cout << "Naam wedstrijd: ";
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
@@ -456,14 +456,17 @@ int main() {
             cout << "Datum (bv. 15-06-2024): ";
             getline(cin, datum);
 
-            cout << "Is NK? (0/1): ";
+            cout << "Is NK? (ja/nee): ";
             cin >> is_nk_keuze;
 
-            cout << "Wisseltijden registreren? (0/1): ";
+            cout << "Wisseltijden registreren? (ja/nee): ";
             cin >> wissels_keuze;
 
+            bool is_nk = (is_nk_keuze == "ja");
+            bool heeft_wissels = (wissels_keuze == "ja");
+
             // nieuw object maken en toevoegen aan de vector
-            Wedstrijd nieuwe_wedstrijd(naam, datum, is_nk_keuze != 0, wissels_keuze != 0);
+            Wedstrijd nieuwe_wedstrijd(naam, datum, is_nk, heeft_wissels);
             wedstrijden.push_back(nieuwe_wedstrijd);
 
             cout << "Wedstrijd aangemaakt met index ["


### PR DESCRIPTION
## Summary
- Ask for `ja/nee` when determining NK status and transition time registration
- Convert answers to booleans with simple string comparison instead of `tolower`

## Testing
- `g++ -std=c++17 *.cpp -o triathlon`


------
https://chatgpt.com/codex/tasks/task_e_68b45a63f254832086b51cb44e6b3530