### PR TITLE
Ensure menu prompt is flushed to console

### DIFF
--- a/Eindopdracht_Triathlon_V2.cpp
+++ b/Eindopdracht_Triathlon_V2.cpp
@@ -214,7 +214,7 @@ void print_keuzemenu()
     cout << "7. Licentie aan atleet koppelen\n";
     cout << "8. Dopingcontrole toevoegen\n";
     cout << "9. Uitslagen tonen\n";
-    cout << "10. Stoppen\n> ";
+    cout << "10. Stoppen\n> " << flush;
 }
 
 // datum helpers voor "dd-mm-jjjj"


### PR DESCRIPTION
## Summary
- Flush the menu prompt in `print_keuzemenu` to guarantee the selection menu is displayed before input is read.

## Testing
- `g++ -std=c++17 Eindopdracht_Triathlon_V2.cpp Atleet.cpp Deelnemer.cpp Wedstrijd.cpp Licentie.cpp -o triathlon`
- `./triathlon <<'EOF'
10
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b5f3bc8cb08320abec0b0ad8140d64